### PR TITLE
Upgrade Hapi FHIR

### DIFF
--- a/dev/hapi/application.yaml
+++ b/dev/hapi/application.yaml
@@ -1,3 +1,4 @@
+# https://raw.githubusercontent.com/hapifhir/hapi-fhir-jpaserver-starter/image/v6.8.3/src/main/resources/application.yaml
 #Adds the option to go to eg. http://localhost:8080/actuator/health for seeing the running configuration
 #see https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
 management:
@@ -58,27 +59,34 @@ hapi:
     openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
     fhir_version: R4
+    ### This flag when enabled to true, will avail evaluate measure operations from CR Module.
+    ### Flag is false by default, can be passed as command line argument to override.
+    cr_enabled: "${CR_ENABLED: false}"
     ### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
     ### to determine the FHIR server address
     #   use_apache_address_strategy: false
     ### forces the use of the https:// protocol for the returned server address.
     ### alternatively, it may be set using the X-Forwarded-Proto header.
     #   use_apache_address_strategy_https: false
-    ### enables the server to host content like HTML, css, etc. under the url pattern of /static/**
+    ### enables the server to host content like HTML, css, etc. under the url pattern of eg. /static/**
+    # staticLocationPrefix: /static
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
-    #    implementationguides:
+    ### tells the server whether to attempt to load IG resources that are already present
+    #    reload_existing_implementationGuides : false
+    #implementationguides:
     ###    example from registry (packages.fhir.org)
-    #      swiss:
-    #        name: swiss.mednet.fhir
-    #        version: 0.8.0
+    #  swiss:
+    #    name: swiss.mednet.fhir
+    #    version: 0.8.0
+    #    reloadExisting : false
     #      example not from registry
     #      ips_1_0_0:
-    #        url: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
+    #        packageUrl: https://build.fhir.org/ig/HL7/fhir-ips/package.tgz
     #        name: hl7.fhir.uv.ips
     #        version: 1.0.0
     #    supported_resource_types:
@@ -94,6 +102,8 @@ hapi:
     #    allow_multiple_delete: true
     #    allow_override_default_search_params: true
     #    auto_create_placeholder_reference_targets: false
+    ### tells the server to automatically append the current version of the target resource to references at these paths
+    #    auto_version_reference_at_paths: Device.patient, Device.location, Device.parent, DeviceMetric.parent, DeviceMetric.source, Observation.device, Observation.subject
     #    cr_enabled: true
     #    ips_enabled: false
     #    default_encoding: JSON
@@ -107,15 +117,15 @@ hapi:
     ###  !!Extended Lucene/Elasticsearch Indexing is still a experimental feature, expect some features (e.g. _total=accurate) to not work as expected!!
     ###  more information here: https://hapifhir.io/hapi-fhir/docs/server_jpa/elastic.html
     advanced_lucene_indexing: false
-    bulk_export_enabled: true
-    bulk_import_enabled: true
+    bulk_export_enabled: false
+    bulk_import_enabled: false
     #    enforce_referential_integrity_on_delete: false
     # This is an experimental feature, and does not fully support _total and other FHIR features.
     #    enforce_referential_integrity_on_delete: false
-    enforce_referential_integrity_on_write: false
+    #    enforce_referential_integrity_on_write: false
     #    etag_support_enabled: true
     #    expunge_enabled: true
-    client_id_strategy: ANY
+    #    client_id_strategy: ALPHANUMERIC
     #    fhirpath_interceptor_enabled: false
     #    filter_search_enabled: true
     #    graphql_enabled: true
@@ -137,14 +147,14 @@ hapi:
     search-coord-core-pool-size: 20
     search-coord-max-pool-size: 100
     search-coord-queue-capacity: 200
-
+    
     # comma-separated package names, will be @ComponentScan'ed by Spring to allow for creating custom Spring beans
     #custom-bean-packages:
-
-    # comma-separated list of fully qualified interceptor classes.
-    # classes listed here will be fetched from the Spring context when combined with 'custom-bean-packages',
-    # or will be instantiated via reflection using an no-arg contructor; then registered with the server
-    #custom-interceptor-classes:
+    
+    # comma-separated list of fully qualified interceptor classes. 
+    # classes listed here will be fetched from the Spring context when combined with 'custom-bean-packages', 
+    # or will be instantiated via reflection using an no-arg contructor; then registered with the server  
+    #custom-interceptor-classes:  
 
     # Threadpool size for BATCH'ed GETs in a bundle.
     #    bundle_batch_pool_size: 10
@@ -195,7 +205,7 @@ hapi:
 #        quitWait:
 #    lastn_enabled: true
 #    store_resource_in_lucene_index_enabled: true
-###  This is configuration for normalized quantity serach level default is 0
+###  This is configuration for normalized quantity search level default is 0
 ###   0: NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED - default
 ###   1: NORMALIZED_QUANTITY_STORAGE_SUPPORTED
 ###   2: NORMALIZED_QUANTITY_SEARCH_SUPPORTED

--- a/dev/hapi/docker-compose.yaml
+++ b/dev/hapi/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   hapi:
-    image: hapiproject/hapi:${FHIR_IMAGE_TAG:-v6.4.4}
+    image: hapiproject/hapi:${FHIR_IMAGE_TAG:-v6.8.3}
     environment:
       SPRING_CONFIG_LOCATION: file:///opt/application.yaml
       hapi.fhir.server_address: https://hapi.${BASE_DOMAIN}/fhir/

--- a/dev/hapi/docker-compose.yaml
+++ b/dev/hapi/docker-compose.yaml
@@ -5,6 +5,12 @@ services:
       SPRING_CONFIG_LOCATION: file:///opt/application.yaml
       hapi.fhir.server_address: https://hapi.${BASE_DOMAIN}/fhir/
       hapi.fhir.tester.home.server_address: https://hapi.${BASE_DOMAIN}/fhir
+
+      hapi.fhir.bulk_export_enabled: "true"
+      hapi.fhir.bulk_import_enabled: "true"
+      # allow FHIR resources to be written even if resources they refer to are not present on the same server
+      hapi.fhir.enforce_referential_integrity_on_write: "false"
+
       spring.datasource.url: jdbc:postgresql://db:5432/hapifhir
       spring.datasource.username: postgres
       spring.datasource.password: postgres


### PR DESCRIPTION
- Upgrade Hapi to latest version (v6.8.3)
- Fixes issues with Bulk Export jobs in Hapi stalling and ultimately failing
  - affects Hapi v6.4.4 to v6.6.0
