### PR TITLE
Update default Aidbox release tag

### DIFF
--- a/dev/aidbox/docker-compose.yaml
+++ b/dev/aidbox/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   aidbox:
-    image: healthsamurai/aidboxone:${FHIR_IMAGE_TAG:-edge}
+    image: healthsamurai/aidboxone:${FHIR_IMAGE_TAG:-2501}
     environment:
       AIDBOX_BASE_URL: https://aidbox.${BASE_DOMAIN}
       AIDBOX_PORT: 8888

--- a/dev/aidbox/docker-compose.yaml
+++ b/dev/aidbox/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   aidbox:
-    image: healthsamurai/aidboxone:${FHIR_IMAGE_TAG:-2501}
+    image: healthsamurai/aidboxone:${FHIR_IMAGE_TAG:-2412}
     environment:
       AIDBOX_BASE_URL: https://aidbox.${BASE_DOMAIN}
       AIDBOX_PORT: 8888


### PR DESCRIPTION
Update default Aidbox release tag to last stable release [2412](https://docs.aidbox.app/overview/release-notes#december-2024-stable-2412)

Use specific release number to avoid surprise upgrades