### PR TITLE
Update Aidbox to 2510 (current stable), for better forms support.

### DIFF
--- a/dev/aidbox/docker-compose.yaml
+++ b/dev/aidbox/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   aidbox:
-    image: healthsamurai/aidboxone:${FHIR_IMAGE_TAG:-2504}
+    image: healthsamurai/aidboxone:${FHIR_IMAGE_TAG:-2510}
     environment:
 
       # Environment variables for Postgres


### PR DESCRIPTION
https://www.health-samurai.io/docs/aidbox/overview/release-notes#october-2025-stable-2510
I'll note that the forms module appears to be enabled in our system already (forms icon at left opens up https://aidbox.fhir-eval.demo.cirg.uw.edu/ui/sdc ), but health samurai has been doing a lot of work on this so I'd like the latest stable.